### PR TITLE
Simplify warning suppression enable Ninja on WIN32

### DIFF
--- a/prj/CMakeCompilers.txt
+++ b/prj/CMakeCompilers.txt
@@ -82,8 +82,10 @@ if (WIN32)
         endif()
        
         # Visual Studio properties
-        add_definitions(/fp:fast)
-        add_definitions(-DUNICODE -D_UNICODE)
+        string(REPLACE ";" " " AdditionalDefinitions "${AdditionalDefinitions}")
+        string(REGEX REPLACE "/W[1-3]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast ${AdditionalDefinitions}")
+        string(REGEX REPLACE "/W[1-3]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:fast ${AdditionalDefinitions}")
+        add_definitions(-DUNICODE -D_UNICODE /nologo)
 
         # Package tool
         set(CMAKE_PACKAGE FALSE CACHE BOOL "Pack executables On/Off")

--- a/prj/CMakeVSWarnings.txt
+++ b/prj/CMakeVSWarnings.txt
@@ -11,225 +11,224 @@
 #
 #------------------------------------------------------------------------------
 macro(setVisualStudioWarnings)
+set(AdditionalDefinitions
 	# Warning level
-    add_definitions("/W4")
-	
-    # C++ exception handler used, but unwind semantics are not enabled.		
-	add_definitions("/wd4530")
-	add_definitions("/wd4514")
-	add_definitions("/wd4625")
-	add_definitions("/wd4626")
+    "/W4"
+    "/wd4530"
+	"/wd4514"
+	"/wd4625"
+	"/wd4626"
 
     # Additional warning over W4	
     # (level 4) enumerator 'identifier' in a switch of enum 'enumeration' is not explicitly handled by a case label.
-    add_definitions("/w44061") 
+    "/w44061" 
 
     # (level 4) enumerator 'identifier' in a switch of enum 'enumeration' is not handled
-    add_definitions("/w44062") 
+    "/w44062" 
 
     # (level 3) 'operator/operation': unsafe conversion from 'type of expression' to 'type required'
-    add_definitions("/w44191") 
+    "/w44191" 
 
     # (level 4) 'identifier': conversion from 'type1' to 'type2', possible loss of data
-    add_definitions("/w44242") 
+    "/w44242" 
 
     # (level 4) 'operator': conversion from 'type1' to 'type2', possible loss of data
-    add_definitions("/w44254")
+    "/w44254"
 
     # (level 4) 'function': no function prototype given: converting '()' to '(void)'
-    add_definitions("/w44255")
+    "/w44255"
 
     # (level 4) 'function': member function does not override any base class virtual member function
-    add_definitions("/w44263")
+    "/w44263"
 
     # (level 1) 'virtual_function': no override available for virtual member function from base 'class'; function is hidden
-    add_definitions("/w44264")
+    "/w44264"
 
     # (level 3) 'class': class has virtual functions, but destructor is not virtual
-    add_definitions("/w44265")
+    "/w44265"
 
     # (level 4) 'function': no override available for virtual member function from base 'type'; function is hidden
-    add_definitions("/w44266")
+    "/w44266"
 
     # (level 3) 'operator': unsigned/negative constant mismatch
-    add_definitions("/w44287")
+    "/w44287"
 
     # (level 4) nonstandard extension used : 'var' : loop control variable declared in the for-loop is used outside the for-loop scope
-    add_definitions("/w44289")
+    "/w44289"
 
     # (level 4) 'operator': expression is always false
-    add_definitions("/w44296")
+    "/w44296"
 
     # (level 2) 'conversion': truncation from 'type1' to 'type2'
-    add_definitions("/w44302")
+    "/w44302"
 
     # (level 1) 'variable' : pointer truncation from 'type' to 'type'
-    add_definitions("/w44311")
+    "/w44311"
 
     # (level 1) 'operation' : conversion from 'type1' to 'type2' of greater size
-    add_definitions("/w44312")
+    "/w44312"
 
     # (level 4) 'type' : use of undefined type detected in CLR meta-data - use of this type may lead to a runtime exception
-    add_definitions("/w44339")
+    "/w44339"
 
     # (level 1) behavior change: 'function' called, but a member operator was called in previous versions
-    add_definitions("/w44342")
+    "/w44342"
 
     # (level 1) behavior change: 'member1' called instead of 'member2'
-    add_definitions("/w44350")
+    "/w44350"
 
     # 'this' : used in base member initializer list
-    add_definitions("/w44355")
+    "/w44355"
 
     # (level 4) 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch
-    add_definitions("/w44365")
+    "/w44365"
 
     # (level 3) layout of class has changed from a previous version of the compiler due to better packing
-    add_definitions("/w44370") 
+    "/w44370" 
 
     # (level 3) layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
-    add_definitions("/w44371")
+    "/w44371"
 
     # (level 4) signed/unsigned mismatch
-    add_definitions("/w44388")
+    "/w44388"
 
     # (level 2) 'function': function signature contains type 'type'; C++ objects are unsafe to pass between pure code and mixed or native
-    add_definitions("/w44412")
+    "/w44412"
 
     # (level 4) missing type specifier - int assumed. Note: C no longer supports default-int
-    add_definitions("/w44431")
+    "/w44431"
 
     # (level 4) 'class1' : Object layout under /vd2 will change due to virtual base 'class2'
-    add_definitions("/w44435")
+    "/w44435"
 
     # (level 4) dynamic_cast from virtual base 'class1' to 'class2' could fail in some contexts
-    add_definitions("/w44437")
+    "/w44437"
 
     # (level 3) top level '__unaligned' is not implemented in this context
-    add_definitions("/w44444") 
+    "/w44444" 
 
     # (level 4) a forward declaration of an unscoped enumeration must have an underlying type (int assumed)
-    add_definitions("/w44471")
+    "/w44471"
 
     # (level 1) 'identifier' is a native enum: add an access specifier (private/public) to declare a managed enum
-    add_definitions("/w44472")
+    "/w44472"
 
     # (level 4) 'function': unreferenced inline function has been removed
-    add_definitions("/w44514")
+    "/w44514"
 
     # (level 4) 'type name': type-name exceeds meta-data limit of 'limit' characters
-    add_definitions("/w44536")
+    "/w44536"
 
     # (level 1) expression before comma evaluates to a function which is missing an argument list
-    add_definitions("/w44545")
+    "/w44545"
 
     # (level 1) function call before comma missing argument list
-    add_definitions("/w44546")
+    "/w44546"
 
     # (level 1) 'operator': operator before comma has no effect; expected operator with side-effect
-    add_definitions("/w44547")
+    "/w44547"
 
     # (level 1) expression before comma has no effect; expected expression with side-effect
-    add_definitions("/w44548")
+    "/w44548"
 
     # (level 1) 'operator': operator before comma has no effect; did you intend 'operator'?
-    add_definitions("/w44549")
+    "/w44549"
 
     # (level 1) expression has no effect; expected expression with side-effect
-    add_definitions("/w44555")
+    "/w44555"
 
     # (level 3) '__assume' contains effect 'effect'
-    add_definitions("/w44557")
+    "/w44557"
 
     # (level 4) informational: catch(�) semantics changed since Visual C++ 7.1; structured exceptions (SEH) are no longer caught
-    add_definitions("/w44571")
+    "/w44571"
 
     # (level 4) 'identifier' is defined to be '0': did you mean to use '#if identifier'?
-    add_definitions("/w44574")
+    "/w44574"
 
     # (level 3) 'symbol1' has already been initialized by another union member in the initializer list, 'symbol2'
-    add_definitions("/w44608") 
+    "/w44608" 
 
     # (level 3) #pragma warning: there is no warning number 'number'
-    add_definitions("/w44619") 
+    "/w44619" 
 
     # (level 4) 'derived class': default constructor could not be generated because a base class default constructor is inaccessible
-    add_definitions("/w44623")
+    "/w44623"
 
     # (level 4) 'derived class': copy constructor could not be generated because a base class copy constructor is inaccessible
-    add_definitions("/w44625")
+    "/w44625"
 
     # (level 4) 'derived class': assignment operator could not be generated because a base class assignment operator is inaccessible
-    add_definitions("/w44626")
+    "/w44626"
 
     # (level 1)	digraphs not supported with -Ze. Character sequence 'digraph' not interpreted as alternate token for 'char'
-    add_definitions("/w44628")
+    "/w44628"
 
     # (level 3)	'instance': construction of local static object is not thread-safe
-    add_definitions("/w44640")
+    "/w44640"
 
     # (level 4)	'symbol' is not defined as a preprocessor macro, replacing with '0' for 'directives'
-    add_definitions("/w44668")
+    "/w44668"
 
     # (level 4)	'symbol' : no directional parameter attribute specified, defaulting to [in]
-    add_definitions("/w44682")
+    "/w44682"
 
     # (level 3)	'user-defined type': possible change in behavior, change in UDT return calling convention
-    add_definitions("/w44686")
+    "/w44686"
 
     # (level 1)	'function': signature of non-private member contains assembly private native type 'native_type'
-    add_definitions("/w44692")
+    "/w44692"
 
     # (level 4)	'function': function not inlined
-    #add_definitions("/w44710")
+    #"/w44710"
 
     # (level 3)	storing 32-bit float result in memory, possible loss of performance
-    add_definitions("/w44738")
+    "/w44738"
 
     # (level 4)	section name 'symbol' is longer than 8 characters and will be truncated by the linker
-    add_definitions("/w44767")
+    "/w44767"
 
     # (level 3)	'symbol' : object name was truncated to 'number' characters in the debug information
-    add_definitions("/w44786")
+    "/w44786"
 
     # We consider it as Compiler optimization
     # (level 4) 'bytes' bytes padding added after construct 'member_name'
-    # add_definitions("/w44820") 
+    # "/w44820" 
 
     # (level 2)	conversion from 'type1' to 'type2' is sign-extended. This may cause unexpected runtime behavior
-    add_definitions("/w44826")
+    "/w44826"
 
     # (level 4) trigraph detected: '??%c' replaced by '%c'
-    add_definitions("/w44837")
+    "/w44837"
 
     # (level 1)	wide string literal cast to 'LPSTR'
-    add_definitions("/w44905")
+    "/w44905"
 
     # (level 1)	string literal cast to 'LPWSTR'
-    add_definitions("/w44906")
+    "/w44906"
 
     # (level 1)	'declarator': a GUID can only be associated with a class, interface, or namespace
-    add_definitions("/w44917")
+    "/w44917"
 
     # (level 1)	illegal copy-initialization; more than one user-defined conversion has been implicitly applied
-    add_definitions("/w44928")
+    "/w44928"
 
     # (level 4)	we are assuming the type library was built for number-bit pointers
-    add_definitions("/w44931")
+    "/w44931"
 
     # (level 1)	reinterpret_cast used between related classes: 'class1' and 'class2'
-    add_definitions("/w44946")
+    "/w44946"
 
     # 'function': profile-guided optimizations disabled because optimizations caused profile data to become inconsistent
-    add_definitions("/w44962")
+    "/w44962"
 
     # (level 4)	'symbol': exception specification does not match previous declaration
-    add_definitions("/w44986")
+    "/w44986"
 
     # (level 4)	nonstandard extension used: 'throw (...)'
-    add_definitions("/w44987")
+    "/w44987"
 
     # (level 4)	'symbol': variable declared outside class/function scope
-    add_definitions("/w44988")
-
+    "/w44988"
+)
 endmacro()


### PR DESCRIPTION
I propose changing the visual C++ warnings into a CMAKE list for easier maintenance.
A side effect of this is that Ninja builds for CI can be integrated.

Documentation for the Ninja build

```
// Batch build using Ninja build tool (VS 2022)
// Generate the build
cmake -DCMAKE_VS_PLATFORM_TOOLSET=v143 -G "Ninja" ../nappgui_sdk/src

// Build the examples
ninja
```
