### PR TITLE
Added "AppleClang" to allowed compiler IDs comparison inside CMakeXCCheckVersion.txt

### DIFF
--- a/prj/CMakeXCCheckVersion.txt
+++ b/prj/CMakeXCCheckVersion.txt
@@ -46,7 +46,7 @@ endfunction()
 
 #------------------------------------------------------------------------------
 macro(checkClangCompiler)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
         message(STATUS "- Clang compiler (${CMAKE_CXX_COMPILER_VERSION})")
         configureMacOSClang()
     else()


### PR DESCRIPTION
This fixed a "compiler not found" error on macOS for me, due to Clang's compiler ID having been renamed to AppleClang for macOS