### PR TITLE
Fix xcode compiling big sur binary for catalina with Xcode <= 12.4

### DIFF
--- a/prj/CMakeXCCheckVersion.txt
+++ b/prj/CMakeXCCheckVersion.txt
@@ -2,6 +2,17 @@
 # This file is part of NAppGUI-SDK project
 # See README.txt and LICENSE.txt
 
+
+# Get macOS version from system
+#------------------------------------------------------------------------------
+function(osVersion _ret)
+    execute_process (
+        COMMAND bash -c "sw_vers -productVersion"
+        OUTPUT_VARIABLE version
+    )
+    set(${_ret} ${version} PARENT_SCOPE)
+endfunction()
+
 # Get macOS name from SDK
 #------------------------------------------------------------------------------
 function(osxSDKName sdkVersion _ret)
@@ -77,12 +88,22 @@ macro(checkXcodeVersion)
     # Xcode 12
     elseif(XCODE_VERSION VERSION_GREATER 11.99)
         checkClangCompiler()
-        set(BASE_OSX_SDK 11.0)
-        set(CMAKE_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimun macOS version required")
-        set_property(CACHE CMAKE_DEPLOYMENT_TARGET PROPERTY STRINGS "11.3;11.2;11.1;11.0;10.15;10.14;10.13;10.12;10.11;10.10;10.9")
-        set(CMAKE_ARCHITECTURE "x86_64" CACHE STRING "Processor architecture")
-        set_property(CACHE CMAKE_ARCHITECTURE PROPERTY STRINGS "x86_64;arm64")
+        osVersion(OS_VERSION)
 
+        # Catalina can use Xcode 12 up to 12.4
+        if(OS_VERSION VERSION_LESS 11.0 AND XCODE_VERSION VERSION_LESS 12.4)
+            set(BASE_OSX_SDK 10.15)
+            set(CMAKE_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimun macOS version required")
+            set_property(CACHE CMAKE_DEPLOYMENT_TARGET PROPERTY STRINGS "10.15;10.14;10.13;10.12;10.11;10.10;10.9")
+            set(CMAKE_ARCHITECTURE "x86_64" CACHE STRING "Processor architecture")
+            set_property(CACHE CMAKE_ARCHITECTURE PROPERTY STRINGS "x86_64")
+        else()
+            set(BASE_OSX_SDK 11.0)
+            set(CMAKE_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimun macOS version required")
+            set_property(CACHE CMAKE_DEPLOYMENT_TARGET PROPERTY STRINGS "11.3;11.2;11.1;11.0;10.15;10.14;10.13;10.12;10.11;10.10;10.9")
+            set(CMAKE_ARCHITECTURE "x86_64" CACHE STRING "Processor architecture")
+            set_property(CACHE CMAKE_ARCHITECTURE PROPERTY STRINGS "x86_64;arm64")
+        endif()
     # Xcode 11
     elseif(XCODE_VERSION VERSION_GREATER 10.99)
         checkClangCompiler()


### PR DESCRIPTION
Hi

This project looks truly incredible! i am baffled how you only have 195 stars, when that's said, thanks for making nappgui ❤️ 

I stumbled upon this minor issue while building the project on macOS Catalina. Apple has gotten less consistent when it comes to removing support for Xcode, ie. not only at major increments... as such you can actually use Xcode 12 on Catalina up to 12.4, which this PR reflects.

The "sw_vers" command has existed for all of mac os x lifetime, so it should be compatible with all mac os versions nappgui supports