### PR TITLE
Let macOS use llvm-clang for compilation too

### DIFF
--- a/prj/NAppCompilers.cmake
+++ b/prj/NAppCompilers.cmake
@@ -132,7 +132,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     endif()
     nap_osx_build_arch(${CMAKE_ARCHITECTURE} CMAKE_OSX_ARCHITECTURES)
 
-    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
         include(${NAPPGUI_ROOT_PATH}/prj/NAppAppleClang.cmake)
         nap_apple_clang_flags()
 


### PR DESCRIPTION
Apple clang is just an slightly modified version of LLVM clang, but LLVM clang is fully useable on macOS and is able to compile and run this project perfectly. Furthermore, if you install LLVM clang with homebrew, it overrides `clang` to use llvm-clang which makes the build fail.