### PR TITLE
Fix CRLF injection in HTTP request headers

### DIFF
--- a/src/inet/httpreq.c
+++ b/src/inet/httpreq.c
@@ -47,6 +47,212 @@ DeclSt(Field);
 
 /*---------------------------------------------------------------------------*/
 
+static bool_t i_valid_header_name_char(const unsigned char c)
+{
+    if (c >= '0' && c <= '9')
+        return TRUE;
+
+    if (c >= 'A' && c <= 'Z')
+        return TRUE;
+
+    if (c >= 'a' && c <= 'z')
+        return TRUE;
+
+    /* Keep header names portable across backends; WinINet drops names with '_'. */
+    switch (c)
+    {
+    case '!':
+    case '#':
+    case '$':
+    case '%':
+    case '&':
+    case '\'':
+    case '*':
+    case '+':
+    case '-':
+    case '.':
+    case '^':
+    case '`':
+    case '|':
+    case '~':
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_utf8_cont(const unsigned char c)
+{
+    return (c & 0xC0) == 0x80 ? TRUE : FALSE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_utf8_next(const unsigned char **str, uint32_t *codepoint)
+{
+    const unsigned char *cstr = NULL;
+
+    cassert_no_null(str);
+    cassert_no_null(codepoint);
+
+    cstr = *str;
+
+    if (*cstr <= 0x7F)
+    {
+        *codepoint = (uint32_t)*cstr;
+        *str = cstr + 1;
+        return TRUE;
+    }
+
+    if (*cstr >= 0xC2 && *cstr <= 0xDF)
+    {
+        if (i_utf8_cont(cstr[1]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x1F) << 6) | (uint32_t)(cstr[1] & 0x3F);
+        *str = cstr + 2;
+        return TRUE;
+    }
+
+    if (*cstr == 0xE0)
+    {
+        if (cstr[1] < 0xA0 || cstr[1] > 0xBF || i_utf8_cont(cstr[2]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x0F) << 12) | ((uint32_t)(cstr[1] & 0x3F) << 6) | (uint32_t)(cstr[2] & 0x3F);
+        *str = cstr + 3;
+        return TRUE;
+    }
+
+    if ((*cstr >= 0xE1 && *cstr <= 0xEC) || (*cstr >= 0xEE && *cstr <= 0xEF))
+    {
+        if (i_utf8_cont(cstr[1]) == FALSE || i_utf8_cont(cstr[2]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x0F) << 12) | ((uint32_t)(cstr[1] & 0x3F) << 6) | (uint32_t)(cstr[2] & 0x3F);
+        *str = cstr + 3;
+        return TRUE;
+    }
+
+    if (*cstr == 0xED)
+    {
+        if (cstr[1] < 0x80 || cstr[1] > 0x9F || i_utf8_cont(cstr[2]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x0F) << 12) | ((uint32_t)(cstr[1] & 0x3F) << 6) | (uint32_t)(cstr[2] & 0x3F);
+        *str = cstr + 3;
+        return TRUE;
+    }
+
+    if (*cstr == 0xF0)
+    {
+        if (cstr[1] < 0x90 || cstr[1] > 0xBF || i_utf8_cont(cstr[2]) == FALSE || i_utf8_cont(cstr[3]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x07) << 18) | ((uint32_t)(cstr[1] & 0x3F) << 12) | ((uint32_t)(cstr[2] & 0x3F) << 6) | (uint32_t)(cstr[3] & 0x3F);
+        *str = cstr + 4;
+        return TRUE;
+    }
+
+    if (*cstr >= 0xF1 && *cstr <= 0xF3)
+    {
+        if (i_utf8_cont(cstr[1]) == FALSE || i_utf8_cont(cstr[2]) == FALSE || i_utf8_cont(cstr[3]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x07) << 18) | ((uint32_t)(cstr[1] & 0x3F) << 12) | ((uint32_t)(cstr[2] & 0x3F) << 6) | (uint32_t)(cstr[3] & 0x3F);
+        *str = cstr + 4;
+        return TRUE;
+    }
+
+    if (*cstr == 0xF4)
+    {
+        if (cstr[1] < 0x80 || cstr[1] > 0x8F || i_utf8_cont(cstr[2]) == FALSE || i_utf8_cont(cstr[3]) == FALSE)
+            return FALSE;
+
+        *codepoint = ((uint32_t)(cstr[0] & 0x07) << 18) | ((uint32_t)(cstr[1] & 0x3F) << 12) | ((uint32_t)(cstr[2] & 0x3F) << 6) | (uint32_t)(cstr[3] & 0x3F);
+        *str = cstr + 4;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_valid_header_value_codepoint(const uint32_t codepoint)
+{
+    if (codepoint == '\t')
+        return TRUE;
+
+    if (codepoint < 32 || codepoint == 127)
+        return FALSE;
+
+    if (codepoint >= 0x80 && codepoint <= 0x9F)
+        return FALSE;
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_valid_header_name(const char_t *name)
+{
+    const unsigned char *cname = cast_const(name, unsigned char);
+
+    if (cname == NULL || *cname == '\0')
+        return FALSE;
+
+    while (*cname != '\0')
+    {
+        if (i_valid_header_name_char(*cname) == FALSE)
+            return FALSE;
+
+        cname += 1;
+    }
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_valid_header_value(const char_t *value)
+{
+    const unsigned char *cvalue = cast_const(value, unsigned char);
+
+    if (cvalue == NULL)
+        return FALSE;
+
+    while (*cvalue != '\0')
+    {
+        uint32_t codepoint = 0;
+
+        if (i_utf8_next(&cvalue, &codepoint) == FALSE)
+            return FALSE;
+
+        if (i_valid_header_value_codepoint(codepoint) == FALSE)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_valid_header(const char_t *name, const char_t *value)
+{
+    if (i_valid_header_name(name) == FALSE)
+        return FALSE;
+
+    if (i_valid_header_value(value) == FALSE)
+        return FALSE;
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
 static void i_remove_field(Field *field)
 {
     cassert_no_null(field);
@@ -110,10 +316,14 @@ void http_clear_headers(Http *http)
 
 /*---------------------------------------------------------------------------*/
 
-void http_add_header(Http *http, const char_t *name, const char_t *value)
+bool_t http_add_header(Http *http, const char_t *name, const char_t *value)
 {
     cassert_no_null(http);
-    oshttp_add_header(http->oshttp, name, value);
+
+    if (i_valid_header(name, value) == FALSE)
+        return FALSE;
+
+    return oshttp_add_header(http->oshttp, name, value);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/inet/httpreq.h
+++ b/src/inet/httpreq.h
@@ -23,7 +23,7 @@ _inet_api void http_destroy(Http **http);
 
 _inet_api void http_clear_headers(Http *http);
 
-_inet_api void http_add_header(Http *http, const char_t *name, const char_t *value);
+_inet_api bool_t http_add_header(Http *http, const char_t *name, const char_t *value);
 
 _inet_api void http_cookies_policy(Http *http, const cookies_t cookies);
 

--- a/src/inet/linux/oshttpreq.c
+++ b/src/inet/linux/oshttpreq.c
@@ -128,13 +128,21 @@ void oshttp_clear_headers(OSHttp *http)
 
 /*---------------------------------------------------------------------------*/
 
-void oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
+bool_t oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
 {
     String *str = NULL;
+    struct curl_slist *headers = NULL;
     cassert(http != NULL);
+
     str = str_printf("%s: %s", name, value);
-    http->headers = curl_slist_append(http->headers, tc(str));
+    headers = curl_slist_append(http->headers, tc(str));
     str_destroy(&str);
+
+    if (headers == NULL)
+        return FALSE;
+
+    http->headers = headers;
+    return TRUE;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/inet/oshttpreq.inl
+++ b/src/inet/oshttpreq.inl
@@ -24,7 +24,7 @@ void oshttp_destroy(OSHttp **http);
 
 void oshttp_clear_headers(OSHttp *http);
 
-void oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value);
+bool_t oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value);
 
 void oshttp_cookies_policy(OSHttp *http, const cookies_t cookies);
 

--- a/src/inet/osx/oshttpreq.m
+++ b/src/inet/osx/oshttpreq.m
@@ -213,17 +213,27 @@ void oshttp_clear_headers(OSHttp *http)
 
 /*---------------------------------------------------------------------------*/
 
-void oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
+bool_t oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
 {
-    if (http->request != nil)
-    {
-        if (i_reserved_header(name) == FALSE)
-        {
-            NSString *lname = [NSString stringWithUTF8String:name];
-            NSString *lvalue = [NSString stringWithUTF8String:value];
-            [http->request setValue:lvalue forHTTPHeaderField:lname];
-        }
-    }
+    NSString *lname = nil;
+    NSString *lvalue = nil;
+
+    cassert_no_null(http);
+
+    if (http->request == nil)
+        return FALSE;
+
+    if (i_reserved_header(name) == TRUE)
+        return FALSE;
+
+    lname = [NSString stringWithUTF8String:name];
+    lvalue = [NSString stringWithUTF8String:value];
+
+    if (lname == nil || lvalue == nil)
+        return FALSE;
+
+    [http->request setValue:lvalue forHTTPHeaderField:lname];
+    return TRUE;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/inet/win/oshttpreq.c
+++ b/src/inet/win/oshttpreq.c
@@ -121,16 +121,17 @@ void oshttp_clear_headers(OSHttp *http)
 
 /*---------------------------------------------------------------------------*/
 
-void oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
+bool_t oshttp_add_header(OSHttp *http, const char_t *name, const char_t *value)
 {
     cassert_no_null(http);
 
     if (stm_bytes_written(http->headers) > 0)
-        stm_writef(http->headers, "\n");
+        stm_writef(http->headers, "\r\n");
 
     stm_writef(http->headers, name);
     stm_writef(http->headers, ": ");
     stm_writef(http->headers, value);
+    return TRUE;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
## Summary

This fixes possible HTTP request header CRLF injection issue in the `inet` HTTP request layer.

`http_add_header` / `oshttp_add_header` previously accepted header names and values without rejecting CR, LF, NUL or other invalid control characters. On Linux the resulting string was passed to libcurl via `curl_slist_append` and on Windows it was written into the header block passed to `HttpSendRequest` and on macOS the same public API accepted unchecked header input before passing it to the Cocoa request backend.

The fix adds shared validation and applies it consistently across Linux, Windows and macOS.

## Changes

- Validate HTTP header names against the RFC token grammar.
- Reject invalid header values containing CR, LF, NUL-equivalent termination, C0/C1 controls, or invalid UTF-8.
- Apply validation on Linux, Windows, and macOS backends.
- Change `http_add_header` and `oshttp_add_header` to return `bool_t` so invalid input is rejected explicitly.
- Preserve valid existing usage while allowing callers to detect rejected headers.
- Use CRLF separators in the Windows request header block.

## Security impact

This prevents callers from accidentally forwarding attacker controlled data into request headers in a way that could inject additional headers or alter request semantics.