### PR TITLE
Harden packed resource parsing

### DIFF
--- a/src/core/respack.c
+++ b/src/core/respack.c
@@ -17,9 +17,9 @@
 #include "buffer.h"
 #include "heap.h"
 #include "hfile.h"
-#include "stream.h"
 #include "strings.h"
 #include <osbs/bfile.h>
+#include <sewer/bmem.h>
 #include <sewer/cassert.h>
 #include <sewer/ptr.h>
 
@@ -28,6 +28,7 @@
 #endif
 
 typedef struct i_resource_t i_Resource;
+typedef struct i_parser_t i_Parser;
 
 enum i_type_t
 {
@@ -55,6 +56,12 @@ struct _respack
     ArrSt(i_Resource) *resources;
 };
 
+struct i_parser_t
+{
+    const byte_t *cur;
+    const byte_t *end;
+};
+
 DeclSt(i_Resource);
 
 /*---------------------------------------------------------------------------*/
@@ -67,6 +74,9 @@ static void i_init_resource(
     void **object)
 {
     cassert_no_null(resource);
+#if defined(__ASSERTS__)
+    resource->id = NULL;
+#endif
     resource->type = type;
     resource->data = data;
     resource->size = size;
@@ -119,8 +129,9 @@ static bool_t i_dump_resources(const ArrSt(i_Resource) *resources, const bool_t 
 
 void respack_destroy(ResPack **pack)
 {
-    cassert_no_null(pack);
-    cassert_no_null(*pack);
+    if (pack == NULL || *pack == NULL)
+        return;
+
     cassert(i_dump_resources((*pack)->resources, FALSE) == TRUE);
     str_destroy(&(*pack)->name);
     arrst_destroy(&(*pack)->resources, i_remove_resource, i_Resource);
@@ -143,53 +154,146 @@ ResPack *respack_embedded(const char_t *name)
 
 /*---------------------------------------------------------------------------*/
 
-static void i_load_object(Stream *stream, const byte_t **data, uint32_t *size, const uint32_t type)
+static uint32_t i_remaining(const i_Parser *parser)
 {
-    /* String */
-    if (type == 0)
-    {
-        uint32_t strsize = stm_read_u32(stream);
-        *data = stm_buffer(stream);
-        *size = 0;
-        stm_skip(stream, strsize + 1);
-    }
-    /* Other file */
-    else
-    {
-        *size = stm_read_u32(stream);
-        *data = stm_buffer(stream);
-        stm_skip(stream, *size);
-    }
+    cassert_no_null(parser);
+    cassert(parser->end >= parser->cur);
+    return (uint32_t)(parser->end - parser->cur);
 }
 
 /*---------------------------------------------------------------------------*/
 
-static void i_load_resource(Stream *stream, const uint32_t locale_code, i_Resource *resource)
+static bool_t i_read_u32(i_Parser *parser, uint32_t *value)
+{
+    cassert_no_null(parser);
+    cassert_no_null(value);
+    if (i_remaining(parser) < sizeof32(uint32_t))
+        return FALSE;
+
+    bmem_copy(cast(value, byte_t), parser->cur, sizeof32(uint32_t));
+    parser->cur += sizeof32(uint32_t);
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_read_data(i_Parser *parser, const byte_t **data, const uint32_t size)
+{
+    cassert_no_null(parser);
+    cassert_no_null(data);
+    if (i_remaining(parser) < size)
+        return FALSE;
+
+    *data = parser->cur;
+    parser->cur += size;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_valid_type(const uint32_t type)
+{
+    return (bool_t)(type <= 2);
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_load_object(i_Parser *parser, const byte_t **data, uint32_t *size, const uint32_t type)
+{
+    uint32_t object_size;
+    const byte_t *object_data = NULL;
+    cassert_no_null(data);
+    cassert_no_null(size);
+
+    if (i_read_u32(parser, &object_size) == FALSE)
+        return FALSE;
+
+    /* String */
+    if (type == 0)
+    {
+        uint32_t stored_size;
+        if (object_size == UINT32_MAX)
+            return FALSE;
+
+        stored_size = object_size + 1;
+        if (i_read_data(parser, &object_data, stored_size) == FALSE)
+            return FALSE;
+
+        if (object_data[object_size] != '\0')
+            return FALSE;
+
+        if (str_len_c(cast_const(object_data, char_t)) != object_size)
+            return FALSE;
+
+        *data = object_data;
+        *size = 0;
+    }
+    /* Other file */
+    else
+    {
+        if (type == 1 && object_size == 0)
+            return FALSE;
+
+        if (i_read_data(parser, &object_data, object_size) == FALSE)
+            return FALSE;
+
+        *data = object_data;
+        *size = object_size;
+    }
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_load_resource(i_Parser *parser, const uint32_t locale_code, const uint32_t num_locales, i_Resource *resource)
 {
     uint32_t type;
     const byte_t *data = NULL;
-    uint32_t size;
+    uint32_t size = 0;
     void *object = NULL;
     uint32_t i, num_localized;
-    type = stm_read_u32(stream);
-    i_load_object(stream, &data, &size, type);
-    num_localized = stm_read_u32(stream);
+
+    if (i_read_u32(parser, &type) == FALSE)
+        return FALSE;
+
+    if (i_valid_type(type) == FALSE)
+        return FALSE;
+
+    if (i_load_object(parser, &data, &size, type) == FALSE)
+        return FALSE;
+
+    if (i_read_u32(parser, &num_localized) == FALSE)
+        return FALSE;
+
+    if (num_localized > i_remaining(parser) / (type == 0 ? 9 : 8))
+        return FALSE;
+
     for (i = 0; i < num_localized; ++i)
     {
-        uint32_t lcode = stm_read_u32(stream);
+        uint32_t lcode;
+        if (i_read_u32(parser, &lcode) == FALSE)
+            return FALSE;
+
+        if (lcode >= num_locales)
+            return FALSE;
+
         if (lcode == locale_code)
         {
-            i_load_object(stream, &data, &size, type);
+            if (i_load_object(parser, &data, &size, type) == FALSE)
+                return FALSE;
         }
         else
         {
             const byte_t *jump_data = NULL;
-            uint32_t jump_size;
-            i_load_object(stream, &jump_data, &jump_size, type);
+            uint32_t jump_size = 0;
+            if (i_load_object(parser, &jump_data, &jump_size, type) == FALSE)
+                return FALSE;
         }
     }
 
     i_init_resource(resource, type, data, size, &object);
+    return TRUE;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -221,34 +325,92 @@ static Buffer *i_load_pack(ArrSt(i_Resource) *resources, const char_t *name, con
     if (buffer != NULL)
     {
         uint32_t locale_code = UINT32_MAX;
-        Stream *stream = stm_from_block(buffer_data(buffer), buffer_size(buffer));
-        uint32_t num_resources;
-        uint32_t i, num_locales = stm_read_u32(stream);
-        for (i = 0; i < num_locales; ++i)
+        i_Parser parser;
+        bool_t ok = TRUE;
+        uint32_t num_resources = 0;
+        uint32_t i, num_locales = 0;
+
+        parser.cur = buffer_data(buffer);
+        parser.end = parser.cur + buffer_size(buffer);
+
+        if (i_read_u32(&parser, &num_locales) == FALSE)
+            ok = FALSE;
+
+        if (ok == TRUE && i_remaining(&parser) < sizeof32(uint32_t))
+            ok = FALSE;
+
+        if (ok == TRUE && num_locales > (i_remaining(&parser) - sizeof32(uint32_t)) / 5)
+            ok = FALSE;
+
+        for (i = 0; ok == TRUE && i < num_locales; ++i)
         {
-            uint32_t locale_size = stm_read_u32(stream);
-            if (locale_code == UINT32_MAX)
+            uint32_t locale_size;
+            const byte_t *locale_data = NULL;
+
+            if (i_read_u32(&parser, &locale_size) == FALSE)
             {
-                const char_t *locale_name = cast_const(stm_buffer(stream), char_t);
+                ok = FALSE;
+                break;
+            }
+
+            if (locale_size == 0)
+            {
+                ok = FALSE;
+                break;
+            }
+
+            if (i_read_data(&parser, &locale_data, locale_size) == FALSE)
+            {
+                ok = FALSE;
+                break;
+            }
+
+            if (locale_data[locale_size - 1] != '\0')
+            {
+                ok = FALSE;
+                break;
+            }
+
+            if (str_len_c(cast_const(locale_data, char_t)) + 1 != locale_size)
+            {
+                ok = FALSE;
+                break;
+            }
+
+            if (locale_code == UINT32_MAX && locale != NULL)
+            {
+                const char_t *locale_name = cast_const(locale_data, char_t);
                 if (str_equ_c(locale, locale_name) == TRUE)
                     locale_code = i;
             }
-
-            stm_skip(stream, locale_size);
         }
 
-        num_resources = stm_read_u32(stream);
-        for (i = 0; i < num_resources; ++i)
+        if (ok == TRUE && i_read_u32(&parser, &num_resources) == FALSE)
+            ok = FALSE;
+
+        if (ok == TRUE && num_resources > i_remaining(&parser) / 12)
+            ok = FALSE;
+
+        for (i = 0; ok == TRUE && i < num_resources; ++i)
         {
-            i_Resource *resource = arrst_new(resources, i_Resource);
-            i_load_resource(stream, locale_code, resource);
+            i_Resource resource;
+            if (i_load_resource(&parser, locale_code, num_locales, &resource) == FALSE)
+            {
+                ok = FALSE;
+                break;
+            }
+
+            arrst_append(resources, resource, i_Resource);
         }
 
-        stm_close(&stream);
-    }
-    else
-    {
-        cassert_fatal_msg(FALSE, "Resource pack can't be loaded.");
+        if (ok == TRUE && parser.cur != parser.end)
+            ok = FALSE;
+
+        if (ok == FALSE)
+        {
+            arrst_clear(resources, i_remove_resource, i_Resource);
+            buffer_destroy(&buffer);
+        }
     }
 
     str_destroy(&resfile);
@@ -262,6 +424,13 @@ ResPack *respack_packed(const char_t *name, const char_t *locale)
     String *lname = str_c(name);
     ArrSt(i_Resource) *resources = arrst_create(i_Resource);
     Buffer *buffer = i_load_pack(resources, name, locale);
+    if (buffer == NULL)
+    {
+        arrst_destroy(&resources, i_remove_resource, i_Resource);
+        str_destroy(&lname);
+        return NULL;
+    }
+
     return i_create_respack(i_ekTYPE_PACKED, &lname, &buffer, &resources);
 }
 
@@ -293,7 +462,11 @@ void respack_add_cdata(ResPack *pack, const uint32_t type, const byte_t *data, c
 
 static ___INLINE const char_t *i_magic(const ResId id)
 {
-    const char_t *magic = str_str(cast_const(id, char_t), "::");
+    const char_t *magic;
+    if (id == NULL)
+        return NULL;
+
+    magic = str_str(cast_const(id, char_t), "::");
     if (magic == NULL)
         return NULL;
     if (str_equ_cn(cast_const(id, char_t), "N23R3C75", (uint32_t)(magic - cast_const(id, char_t))) == FALSE)
@@ -305,15 +478,64 @@ static ___INLINE const char_t *i_magic(const ResId id)
 
 /*---------------------------------------------------------------------------*/
 
-static ___INLINE uint32_t i_index(ResId id, const String *name)
+static bool_t i_parse_index(const char_t *str, uint32_t *index)
+{
+    uint32_t value = 0;
+    bool_t has_digit = FALSE;
+    cassert_no_null(index);
+
+    if (str == NULL)
+        return FALSE;
+
+    while (*str != '\0')
+    {
+        uint32_t digit;
+        if (*str < '0' || *str > '9')
+            return FALSE;
+
+        has_digit = TRUE;
+        digit = (uint32_t)(*str - '0');
+        if (value > (UINT32_MAX - digit) / 10)
+            return FALSE;
+
+        value = value * 10 + digit;
+        str += 1;
+    }
+
+    if (has_digit == FALSE)
+        return FALSE;
+
+    *index = value;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static ___INLINE bool_t i_index(ResId id, const String *name, uint32_t *index)
 {
     const char_t *idr = i_magic(id);
     const char_t *packid = NULL;
-    cassert_no_null(idr);
+    uint32_t name_size;
+    if (index == NULL)
+        return FALSE;
+
+    *index = 0;
+
+    if (idr == NULL || name == NULL)
+        return FALSE;
+
     packid = str_str(idr, "::");
-    cassert_no_null(packid);
-    cassert_unref(str_equ_cn(tc(name), idr, (uint32_t)(packid - idr)) == TRUE, name);
-    return str_to_u32(packid + 2, 10, NULL);
+    if (packid == NULL)
+        return FALSE;
+
+    name_size = (uint32_t)(packid - idr);
+    if (str_len(name) != name_size)
+        return FALSE;
+
+    if (str_equ_cn(tc(name), idr, name_size) == FALSE)
+        return FALSE;
+
+    return i_parse_index(packid + 2, index);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -321,10 +543,17 @@ static ___INLINE uint32_t i_index(ResId id, const String *name)
 const char_t *respack_text(const ResPack *pack, const ResId id)
 {
     i_Resource *resource = NULL;
-    cassert_no_null(pack);
-    resource = arrst_get(pack->resources, i_index(id, pack->name), i_Resource);
-    cassert_no_null(resource);
-    cassert(resource->type == 0);
+    uint32_t index;
+    if (pack == NULL || i_index(id, pack->name, &index) == FALSE)
+        return NULL;
+
+    if (index >= arrst_size(pack->resources, i_Resource))
+        return NULL;
+
+    resource = arrst_get(pack->resources, index, i_Resource);
+    if (resource == NULL || resource->type != 0 || resource->data == NULL)
+        return NULL;
+
     return cast_const(resource->data, char_t);
 }
 
@@ -333,10 +562,19 @@ const char_t *respack_text(const ResPack *pack, const ResId id)
 const byte_t *respack_file(const ResPack *pack, const ResId id, uint32_t *size)
 {
     i_Resource *resource = NULL;
-    cassert_no_null(pack);
-    resource = arrst_get(pack->resources, i_index(id, pack->name), i_Resource);
-    cassert_no_null(resource);
-    cassert(resource->type == 2);
+    uint32_t index;
+    ptr_assign(size, 0);
+
+    if (pack == NULL || i_index(id, pack->name, &index) == FALSE)
+        return NULL;
+
+    if (index >= arrst_size(pack->resources, i_Resource))
+        return NULL;
+
+    resource = arrst_get(pack->resources, index, i_Resource);
+    if (resource == NULL || resource->type != 2 || resource->data == NULL)
+        return NULL;
+
     ptr_assign(size, resource->size);
     return resource->data;
 }
@@ -346,14 +584,22 @@ const byte_t *respack_file(const ResPack *pack, const ResId id, uint32_t *size)
 void *respack_object_imp(const ResPack *pack, const ResId id, FPtr_from_data func_create, FPtr_destroy func_destroy)
 {
     i_Resource *resource = NULL;
-    cassert_no_null(pack);
-    resource = arrst_get(pack->resources, i_index(id, pack->name), i_Resource);
-    cassert_no_null(resource);
+    uint32_t index;
+    if (pack == NULL || i_index(id, pack->name, &index) == FALSE)
+        return NULL;
+
+    if (index >= arrst_size(pack->resources, i_Resource))
+        return NULL;
+
+    resource = arrst_get(pack->resources, index, i_Resource);
+    if (resource == NULL || resource->type == 0 || resource->data == NULL)
+        return NULL;
+
     if (resource->object == NULL)
     {
-        cassert_no_nullf(func_create);
-        cassert_no_nullf(func_destroy);
-        cassert(resource->func_destroy == NULL);
+        if (func_create == NULL || func_destroy == NULL)
+            return NULL;
+
         resource->object = func_create(resource->data, resource->size);
         resource->func_destroy = func_destroy;
     }
@@ -367,21 +613,22 @@ static ___INLINE i_Resource *i_resource(const ArrPt(ResPack) *packs, const ResId
 {
     const char_t *idr = i_magic(id);
     const char_t *packid = NULL;
-    cassert_no_null(is_resid);
-    *is_resid = (bool_t)(idr != NULL);
+    if (is_resid != NULL)
+        *is_resid = (bool_t)(idr != NULL);
 
-    if (idr == NULL)
+    if (idr == NULL || packs == NULL)
         return NULL;
 
     packid = str_str(idr, "::");
     if (packid != NULL)
     {
+        uint32_t name_size = (uint32_t)(packid - idr);
         arrpt_foreach_const(pack, packs, ResPack)
-            if (str_cmp_cn(tc(pack->name), idr, (uint32_t)(packid - idr)) == 0)
+            if (pack != NULL && str_len(pack->name) == name_size && str_cmp_cn(tc(pack->name), idr, name_size) == 0)
             {
                 uint32_t idx;
-                idx = str_to_u32(packid + 2, 10, NULL);
-                return arrst_get(pack->resources, idx, i_Resource);
+                if (i_parse_index(packid + 2, &idx) == TRUE && idx < arrst_size(pack->resources, i_Resource))
+                    return arrst_get(pack->resources, idx, i_Resource);
             }
         arrpt_end()
     }
@@ -395,13 +642,11 @@ const char_t *respack_atext(const ArrPt(ResPack) *packs, const ResId id, bool_t 
     const i_Resource *resource = i_resource(packs, id, is_resid);
     if (resource != NULL)
     {
-        cassert(resource->type == 0);
-        return cast_const(resource->data, char_t);
+        if (resource->type == 0 && resource->data != NULL)
+            return cast_const(resource->data, char_t);
     }
-    else
-    {
-        return NULL;
-    }
+
+    return NULL;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -411,9 +656,11 @@ const byte_t *respack_afile(const ArrPt(ResPack) *packs, const ResId id, uint32_
     i_Resource *resource = i_resource(packs, id, is_resid);
     if (resource != NULL)
     {
-        cassert(resource->type == 2);
-        ptr_assign(size, resource->size);
-        return resource->data;
+        if (resource->type == 2 && resource->data != NULL)
+        {
+            ptr_assign(size, resource->size);
+            return resource->data;
+        }
     }
 
     ptr_assign(size, 0);
@@ -427,11 +674,14 @@ void *respack_aobj_imp(const ArrPt(ResPack) *packs, const ResId id, FPtr_from_da
     i_Resource *resource = i_resource(packs, id, is_resid);
     if (resource != NULL)
     {
+        if (resource->type == 0 || resource->data == NULL)
+            return NULL;
+
         if (resource->object == NULL)
         {
-            cassert_no_nullf(func_create);
-            cassert_no_nullf(func_destroy);
-            cassert(resource->func_destroy == NULL);
+            if (func_create == NULL || func_destroy == NULL)
+                return NULL;
+
 #if defined(__ASSERTS__)
             resource->id = id;
 #endif

--- a/src/draw2d/image.c
+++ b/src/draw2d/image.c
@@ -241,7 +241,11 @@ Image *image_from_file(const char_t *pathname, ferror_t *error)
 
 Image *image_from_data(const byte_t *data, const uint32_t size)
 {
-    codec_t codec = i_codec(data[0]);
+    codec_t codec;
+    if (data == NULL || size == 0)
+        return NULL;
+
+    codec = i_codec(data[0]);
     if (codec != ENUM_MAX(codec_t))
     {
         OSImage *osimage = NULL;

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -219,7 +219,8 @@ void gui_language(const char_t *lang)
     arrpt_clear(i_PACKS, respack_destroy, ResPack);
     arrst_foreach(func_pack, i_FUNC_PACKS, FPtr_respack)
         ResPack *pack = (*func_pack)(lang);
-        arrpt_append(i_PACKS, pack, ResPack);
+        if (pack != NULL)
+            arrpt_append(i_PACKS, pack, ResPack);
     arrpt_end()
 
     arrpt_foreach(menu, i_MENUS, Menu)
@@ -241,7 +242,7 @@ const char_t *gui_text(const ResId id)
     bool_t is_resid;
     const char_t *text = respack_atext(i_PACKS, id, &is_resid);
     if (is_resid == TRUE)
-        return text;
+        return text != NULL ? text : "";
     else
         return id;
 }


### PR DESCRIPTION
## Summary

This hardens `.res` packed resource loading against malformed or attacker controlled metadata.

The parser now uses explicit cursor based reads with remaining buffer checks, validates counts and sizes before advancing, enforces NUL termination for packed strings/locales, validates locale indexes and rejects packs that don't parse to the exact end of the buffer.

## Security fixes

Addresses: resource pack parser trusts untrusted metadata.

Key protections added:

- Reject truncated reads for counts, locale names, resource objects, and localized resources.
- Bound `num_locales`, `num_resources`, and `num_localized` by the remaining buffer.
- Require NUL terminated locale and string resources.
- Reject embedded NULs in string resources.
- Reject invalid resource types.
- Reject zero-length packed image objects.
- Reject trailing bytes after the last parsed resource.
- Return `NULL` for invalid packed resource files instead of exposing partially parsed resources.
- Harden resource lookups against malformed `ResId` values and out of range indexes.
- Add a defensive zero length input guard in `image_from_data`.

## Behavior notes

If a packed resource file is missing or malformed, `respack_packed` now returns `NULL`. GUI resource registration skips failed packs, and missing localized text resolves safely to an empty string instead of dereferencing invalid data.