### PR TITLE
Harden Base64 bounds and JSON parser nesting

### DIFF
--- a/src/encode/base64.c
+++ b/src/encode/base64.c
@@ -18,7 +18,45 @@
 #include <core/strings.h>
 #include <sewer/cassert.h>
 
+#define i_B64_MAX_ENCODED_SIZE ((uint64_t)UINT32_MAX - 1024ULL)
+
 static char_t i_B64_CHR[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_b64_encoded_size(const uint32_t data_size, uint32_t *encoded_size)
+{
+    uint64_t size = 4ULL * ((uint64_t)data_size / 3ULL) + 5ULL;
+
+    cassert_no_null(encoded_size);
+
+    if (size > i_B64_MAX_ENCODED_SIZE)
+    {
+        *encoded_size = 0;
+        return FALSE;
+    }
+
+    *encoded_size = (uint32_t)size;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_b64_required_size(const uint32_t data_size, uint32_t *required_size)
+{
+    uint64_t size = ((((uint64_t)data_size + 2ULL) / 3ULL) * 4ULL) + 1ULL;
+
+    cassert_no_null(required_size);
+
+    if (size > (uint64_t)UINT32_MAX)
+    {
+        *required_size = 0;
+        return FALSE;
+    }
+
+    *required_size = (uint32_t)size;
+    return TRUE;
+}
 
 /*---------------------------------------------------------------------------*/
 
@@ -49,10 +87,43 @@ static uint32_t i_b64_int(const uint32_t ch)
 
 /*---------------------------------------------------------------------------*/
 
+static bool_t i_b64_decoded_bytes(const char_t *base64, const uint32_t size, uint32_t *decoded_size)
+{
+    uint32_t i = 0, j = 0, k = 0, s[4];
+
+    cassert_no_null(decoded_size);
+    *decoded_size = 0;
+
+    if (base64 == NULL)
+        return FALSE;
+
+    for (i = 0; i < size; i++)
+    {
+        s[j++] = i_b64_int((uint32_t) * (base64 + i));
+        if (j == 4)
+        {
+            if (s[2] == 64)
+                k += 1;
+            else if (s[3] == 64)
+                k += 2;
+            else
+                k += 3;
+
+            j = 0;
+        }
+    }
+
+    *decoded_size = k;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
 uint32_t b64_encoded_size(const uint32_t data_size)
 {
-    uint32_t size = 4 * (data_size / 3);
-    return size + 4 + 1;
+    uint32_t size = 0;
+    i_b64_encoded_size(data_size, &size);
+    return size;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -65,11 +136,9 @@ uint32_t b64_decoded_size(const uint32_t encoded_size)
 
 /*---------------------------------------------------------------------------*/
 
-uint32_t b64_encode(const byte_t *data, const uint32_t size, char_t *base64, const uint32_t esize)
+static uint32_t i_b64_encode(const byte_t *data, const uint32_t size, char_t *base64)
 {
     uint32_t i = 0, j = 0, k = 0, s[3];
-    cassert_no_null(data);
-    cassert_no_null(base64);
     for (i = 0; i < size; i++)
     {
         s[j++] = *(data + i);
@@ -105,19 +174,59 @@ uint32_t b64_encode(const byte_t *data, const uint32_t size, char_t *base64, con
         k += 4;
     }
 
-    cassert_unref(k < esize, esize);
     base64[k] = '\0';
     return k;
 }
 
 /*---------------------------------------------------------------------------*/
 
-uint32_t b64_decode(const char_t *base64, const uint32_t size, byte_t *data)
+bool_t b64_encode_ex(const byte_t *data, const uint32_t size, char_t *base64, const uint32_t esize, uint32_t *written)
+{
+    uint32_t required_size = 0;
+    uint32_t n = 0;
+
+    if (written != NULL)
+        *written = 0;
+
+    if (base64 == NULL || (data == NULL && size > 0))
+        return FALSE;
+
+    if (i_b64_required_size(size, &required_size) == FALSE || esize < required_size)
+    {
+        if (base64 != NULL && esize > 0)
+            base64[0] = '\0';
+        return FALSE;
+    }
+
+    n = i_b64_encode(data, size, base64);
+    if (written != NULL)
+        *written = n;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+uint32_t b64_encode(const byte_t *data, const uint32_t size, char_t *base64, const uint32_t esize)
+{
+    uint32_t required_size = 0;
+    bool_t required_ok = FALSE;
+
+    cassert_no_null(data);
+    cassert_no_null(base64);
+    required_ok = i_b64_required_size(size, &required_size);
+    cassert(required_ok == TRUE);
+    cassert_unref(required_size <= esize, esize);
+    unref(required_ok);
+    unref(required_size);
+
+    return i_b64_encode(data, size, base64);
+}
+
+/*---------------------------------------------------------------------------*/
+
+static uint32_t i_b64_decode(const char_t *base64, const uint32_t size, byte_t *data)
 {
     uint32_t i = 0, j = 0, k = 0, s[4];
-
-    cassert_no_null(base64);
-    cassert_no_null(data);
 
     for (i = 0; i < size; i++)
     {
@@ -154,12 +263,53 @@ uint32_t b64_decode(const char_t *base64, const uint32_t size, byte_t *data)
 
 /*---------------------------------------------------------------------------*/
 
+bool_t b64_decode_ex(const char_t *base64, const uint32_t size, byte_t *data, const uint32_t dsize, uint32_t *written)
+{
+    uint32_t k = 0;
+    uint32_t required_size = 0;
+
+    if (written != NULL)
+        *written = 0;
+
+    if (base64 == NULL || data == NULL)
+        return FALSE;
+
+    if (i_b64_decoded_bytes(base64, size, &required_size) == FALSE || required_size > dsize)
+        return FALSE;
+
+    k = i_b64_decode(base64, size, data);
+    if (written != NULL)
+        *written = k;
+
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+uint32_t b64_decode(const char_t *base64, const uint32_t size, byte_t *data)
+{
+    cassert_no_null(base64);
+    cassert_no_null(data);
+
+    return i_b64_decode(base64, size, data);
+}
+
+/*---------------------------------------------------------------------------*/
+
 static String *i_encode_from_data(const byte_t *data, const uint32_t size)
 {
     uint32_t b64size = b64_encoded_size(size);
-    String *str = str_reserve(b64size);
-    char_t *b64data = tcc(str);
-    uint32_t n = b64_encode(data, size, b64data, b64size);
+    String *str = NULL;
+    char_t *b64data = NULL;
+    uint32_t n = 0;
+
+    if (b64size == 0)
+        return str_c("");
+
+    str = str_reserve(b64size);
+    b64data = tcc(str);
+    if (b64_encode_ex(data, size, b64data, b64size, &n) == FALSE)
+        n = 0;
     b64data[n] = '\0';
     return str;
 }
@@ -231,8 +381,11 @@ Buffer *b64_decode_from_data(const byte_t *data, const uint32_t size)
 {
     uint32_t dsize = b64_decoded_size(size);
     byte_t *binary = heap_malloc(dsize, "b64_decode");
-    uint32_t binsize = b64_decode(cast_const(data, char_t), size, binary);
-    Buffer *buffer = buffer_with_data(binary, binsize);
+    uint32_t binsize = 0;
+    Buffer *buffer = NULL;
+
+    b64_decode_ex(cast_const(data, char_t), size, binary, dsize, &binsize);
+    buffer = buffer_with_data(binary, binsize);
     heap_free(&binary, dsize, "b64_decode");
     return buffer;
 }

--- a/src/encode/base64.h
+++ b/src/encode/base64.h
@@ -19,7 +19,11 @@ _encode_api uint32_t b64_encoded_size(const uint32_t data_size);
 
 _encode_api uint32_t b64_decoded_size(const uint32_t encoded_size);
 
+_encode_api bool_t b64_encode_ex(const byte_t *data, const uint32_t size, char_t *base64, const uint32_t esize, uint32_t *written);
+
 _encode_api uint32_t b64_encode(const byte_t *data, const uint32_t size, char_t *base64, const uint32_t esize);
+
+_encode_api bool_t b64_decode_ex(const char_t *base64, const uint32_t size, byte_t *data, const uint32_t dsize, uint32_t *written);
 
 _encode_api uint32_t b64_decode(const char_t *base64, const uint32_t size, byte_t *data);
 

--- a/src/encode/json.c
+++ b/src/encode/json.c
@@ -24,6 +24,8 @@
 #include <sewer/ptr.h>
 #include <sewer/unicode.h>
 
+#define i_MAX_JSON_DEPTH 256
+
 typedef enum _jtoken_t
 {
     i_ekTRUE,
@@ -50,6 +52,8 @@ struct i_parser_t
     uint32_t col;
     uint32_t row;
     uint32_t lexsize;
+    uint32_t depth;
+    bool_t unrecoverable;
     const char_t *lexeme;
     char_t number[128];
     ArrPt(String) *log;
@@ -61,7 +65,7 @@ static byte_t *i_create_type(i_Parser *parser, const DBind *bind, const DBind *e
 static bool_t i_jump_json_value(i_Parser *parser);
 static bool_t i_parse_json_value(i_Parser *parser, const DBind *bind, const DBind *ebind, const bool_t is_str_dptr, byte_t *data, bool_t *null_readed);
 static bool_t i_parse_json_object(i_Parser *parser, const DBind *stbind, byte_t *obj);
-static void i_write_json_value(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data);
+static void i_write_json_value(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data, bool_t *failed);
 
 /*---------------------------------------------------------------------------*/
 
@@ -89,14 +93,67 @@ static bool_t i_error(const bool_t cond, const bool_t fatal, i_Parser *parser, c
 
 /*---------------------------------------------------------------------------*/
 
+static bool_t i_enter_json_level(i_Parser *parser)
+{
+    cassert_no_null(parser);
+
+    if (parser->depth >= i_MAX_JSON_DEPTH)
+    {
+        parser->unrecoverable = TRUE;
+        return i_error(FALSE, TRUE, parser, "Maximum Json nesting depth exceeded");
+    }
+
+    parser->depth += 1;
+    return TRUE;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static bool_t i_leave_json_level(i_Parser *parser, const bool_t result)
+{
+    cassert_no_null(parser);
+    cassert(parser->depth > 0);
+    parser->depth -= 1;
+    return result;
+}
+
+/*---------------------------------------------------------------------------*/
+
 static void i_new_token(i_Parser *parser)
 {
     ltoken_t token;
     cassert_no_null(parser);
-    token = stm_read_token(parser->stm);
-    parser->row = stm_token_col(parser->stm);
-    parser->col = stm_token_row(parser->stm);
-    parser->lexeme = stm_token_lexeme(parser->stm, &parser->lexsize);
+
+    for (;;)
+    {
+        token = stm_read_token(parser->stm);
+        parser->row = stm_token_col(parser->stm);
+        parser->col = stm_token_row(parser->stm);
+        parser->lexeme = stm_token_lexeme(parser->stm, &parser->lexsize);
+
+        if (token == ekTMINUS)
+        {
+            if (parser->minus == TRUE)
+            {
+                parser->minus = FALSE;
+                parser->token = i_ekUNKNOWN;
+                return;
+            }
+
+            parser->minus = TRUE;
+            continue;
+        }
+
+        if (parser->minus == TRUE && token != ekTINTEGER && token != ekTREAL)
+        {
+            parser->minus = FALSE;
+            parser->token = i_ekUNKNOWN;
+            return;
+        }
+
+        break;
+    }
+
     switch (token)
     {
     case ekTIDENT:
@@ -158,9 +215,8 @@ static void i_new_token(i_Parser *parser)
         break;
 
     case ekTMINUS:
-        cassert(parser->minus == FALSE);
-        parser->minus = TRUE;
-        i_new_token(parser);
+        cassert(FALSE);
+        parser->token = i_ekUNKNOWN;
         break;
 
     case ekTSLCOM:
@@ -210,6 +266,9 @@ static bool_t i_jump_json_array(i_Parser *parser)
 
     if (ok == FALSE)
     {
+        if (parser->unrecoverable == TRUE)
+            return FALSE;
+
         /* Empty array */
         if (parser->token == i_ekCLOSE_ARRAY)
             return TRUE;
@@ -227,6 +286,8 @@ static bool_t i_jump_json_array(i_Parser *parser)
             return i_error(FALSE, TRUE, parser, "Comma expected jumping array");
 
         ok = i_jump_json_value(parser);
+        if (ok == FALSE && parser->unrecoverable == TRUE)
+            return FALSE;
     }
 }
 
@@ -292,9 +353,13 @@ static bool_t i_jump_json_value(i_Parser *parser)
     case i_ekSTRING:
         return TRUE;
     case i_ekOPEN_ARRAY:
-        return i_jump_json_array(parser);
+        if (i_enter_json_level(parser) == FALSE)
+            return FALSE;
+        return i_leave_json_level(parser, i_jump_json_array(parser));
     case i_ekOPEN_OBJECT:
-        return i_jump_json_object(parser);
+        if (i_enter_json_level(parser) == FALSE)
+            return FALSE;
+        return i_leave_json_level(parser, i_jump_json_object(parser));
     case i_ekCLOSE_ARRAY:
         return FALSE;
     case i_ekCLOSE_OBJECT:
@@ -325,6 +390,9 @@ static bool_t i_parse_json_array(i_Parser *parser, const DBind *bind, const DBin
 
     if (ok == FALSE)
     {
+        if (parser->unrecoverable == TRUE)
+            return FALSE;
+
         /* Empty array, we have to remove the first element added to parse value */
         if (parser->token == i_ekCLOSE_ARRAY)
         {
@@ -356,7 +424,12 @@ static bool_t i_parse_json_array(i_Parser *parser, const DBind *bind, const DBin
         dbind_init_data(ebind, data);
         ok = i_parse_json_value(parser, ebind, NULL, FALSE, data, NULL);
         if (ok == FALSE)
+        {
+            if (parser->unrecoverable == TRUE)
+                return FALSE;
+
             dbind_set_value_null(ebind, NULL, FALSE, data);
+        }
     }
 }
 
@@ -368,6 +441,9 @@ static bool_t i_parse_json_arrpt(i_Parser *parser, const DBind *bind, const DBin
 
     if (data == NULL)
     {
+        if (parser->unrecoverable == TRUE)
+            return FALSE;
+
         /* Empty array */
         if (parser->token == i_ekCLOSE_ARRAY)
             return TRUE;
@@ -388,6 +464,8 @@ static bool_t i_parse_json_arrpt(i_Parser *parser, const DBind *bind, const DBin
             return i_error(FALSE, TRUE, parser, "Comma expected in 'array'");
 
         data = i_create_type(parser, ebind, NULL);
+        if (parser->unrecoverable == TRUE)
+            return FALSE;
     }
 }
 
@@ -433,7 +511,8 @@ static bool_t i_parse_json_value(i_Parser *parser, const DBind *bind, const DBin
         {
             uint32_t dsize = b64_decoded_size(parser->lexsize);
             byte_t *b64 = heap_malloc(dsize, "JsonB64Decode");
-            uint32_t b64size = b64_decode(parser->lexeme, parser->lexsize, b64);
+            uint32_t b64size = 0;
+            b64_decode_ex(parser->lexeme, parser->lexsize, b64, dsize, &b64size);
             rset = dbind_create_value_binary(bind, data, b64, b64size);
             heap_free(&b64, dsize, "JsonB64Decode");
         }
@@ -449,36 +528,43 @@ static bool_t i_parse_json_value(i_Parser *parser, const DBind *bind, const DBin
             byte_t *cont = *dcast(data, byte_t);
             if (cont != NULL)
                 cassert(dbind_container_size(bind, cont) == 0);
+            if (i_enter_json_level(parser) == FALSE)
+                return FALSE;
             if (dbind_container_is_ptr(bind) == TRUE)
-                return i_parse_json_arrpt(parser, bind, ebind, cont);
+                return i_leave_json_level(parser, i_parse_json_arrpt(parser, bind, ebind, cont));
             else
-                return i_parse_json_array(parser, bind, ebind, cont);
+                return i_leave_json_level(parser, i_parse_json_array(parser, bind, ebind, cont));
         }
         else
         {
             bool_t err = i_error(FALSE, TRUE, parser, "Unexpected Json '['");
-            i_jump_json_array(parser);
+            if (i_enter_json_level(parser) == TRUE)
+                i_leave_json_level(parser, i_jump_json_array(parser));
             return err;
         }
 
     case i_ekOPEN_OBJECT:
         if (type == ekDTYPE_STRUCT)
         {
+            if (i_enter_json_level(parser) == FALSE)
+                return FALSE;
+
             if (is_str_dptr == TRUE)
             {
                 if (*dcast(data, byte_t) == NULL)
                     *dcast(data, byte_t) = dbind_create_data(bind, ebind);
-                return i_parse_json_object(parser, bind, *dcast(data, byte_t));
+                return i_leave_json_level(parser, i_parse_json_object(parser, bind, *dcast(data, byte_t)));
             }
             else
             {
-                return i_parse_json_object(parser, bind, data);
+                return i_leave_json_level(parser, i_parse_json_object(parser, bind, data));
             }
         }
         else
         {
             bool_t err = i_error(FALSE, TRUE, parser, "Unexpected Json '{'");
-            i_jump_json_object(parser);
+            if (i_enter_json_level(parser) == TRUE)
+                i_leave_json_level(parser, i_jump_json_object(parser));
             return err;
         }
 
@@ -559,7 +645,12 @@ static bool_t i_parse_json_object(i_Parser *parser, const DBind *stbind, byte_t 
             byte_t *data = obj + dbind_st_offset(stbind, member_id);
             bool_t null_readed = FALSE;
             if (i_parse_json_value(parser, bind, ebind, is_str_dptr, data, &null_readed) == FALSE)
+            {
+                if (parser->unrecoverable == TRUE)
+                    return FALSE;
+
                 dbind_st_set_value_null(stbind, member_id, obj);
+            }
             else if (null_readed == TRUE)
                 dbind_st_set_value_null(stbind, member_id, obj);
             comma_state = FALSE;
@@ -661,6 +752,8 @@ void *json_read_imp(Stream *stm, const JsonOpts *opts, const char_t *type)
     parser.row = 0;
     parser.lexeme = NULL;
     parser.lexsize = 0;
+    parser.depth = 0;
+    parser.unrecoverable = FALSE;
     parser.minus = FALSE;
     parser.log = opts ? opts->log : NULL;
     i_bind_from_typename(type, &bind, &ebind);
@@ -720,7 +813,7 @@ static void i_write_escape_str(Stream *stm, const char_t *cstr)
 
 /*---------------------------------------------------------------------------*/
 
-static void i_write_container(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data)
+static void i_write_container(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data, bool_t *failed)
 {
     const byte_t *cont = data;
     uint32_t i, n = dbind_container_size(bind, cont);
@@ -728,7 +821,7 @@ static void i_write_container(Stream *stm, const DBind *bind, const DBind *ebind
     for (i = 0; i < n; ++i)
     {
         const byte_t *elem = dbind_container_cget(bind, ebind, i, cont);
-        i_write_json_value(stm, ebind, NULL, elem);
+        i_write_json_value(stm, ebind, NULL, elem, failed);
         if (i < n - 1)
             stm_writef(stm, ", ");
     }
@@ -737,7 +830,7 @@ static void i_write_container(Stream *stm, const DBind *bind, const DBind *ebind
 
 /*---------------------------------------------------------------------------*/
 
-static void i_write_object(Stream *stm, const DBind *stbind, const byte_t *obj)
+static void i_write_object(Stream *stm, const DBind *stbind, const byte_t *obj, bool_t *failed)
 {
     uint32_t i, n = dbind_st_count(stbind);
     cassert_no_null(obj);
@@ -756,7 +849,7 @@ static void i_write_object(Stream *stm, const DBind *stbind, const byte_t *obj)
         if (type == ekDTYPE_STRING || type == ekDTYPE_BINARY || type == ekDTYPE_CONTAINER || is_str_dptr)
             mdata = *dcast_const(mdata, byte_t);
 
-        i_write_json_value(stm, mbind, mebind, mdata);
+        i_write_json_value(stm, mbind, mebind, mdata, failed);
         if (i < n - 1)
             stm_writef(stm, ", ");
     }
@@ -765,7 +858,7 @@ static void i_write_object(Stream *stm, const DBind *stbind, const byte_t *obj)
 
 /*---------------------------------------------------------------------------*/
 
-static void i_write_binary(Stream *stm, const DBind *bind, const byte_t *data)
+static void i_write_binary(Stream *stm, const DBind *bind, const byte_t *data, bool_t *failed)
 {
     Stream *objstm = stm_memory(1024);
     const byte_t *stmdata = NULL;
@@ -777,12 +870,29 @@ static void i_write_binary(Stream *stm, const DBind *bind, const byte_t *data)
     if (stmsize > 0)
     {
         uint32_t b64size = b64_encoded_size(stmsize);
-        char_t *b64data = cast(heap_malloc(b64size, "JsonB64Encode"), char_t);
-        b64_encode(stmdata, stmsize, b64data, b64size);
-        stm_writef(stm, "\"");
-        stm_writef(stm, b64data);
-        stm_writef(stm, "\"");
-        heap_free(dcast(&b64data, byte_t), b64size, "JsonB64Encode");
+        if (b64size > 0)
+        {
+            char_t *b64data = cast(heap_malloc(b64size, "JsonB64Encode"), char_t);
+            bool_t ok = b64_encode_ex(stmdata, stmsize, b64data, b64size, NULL);
+            cassert(ok == TRUE);
+            if (ok == TRUE)
+            {
+                stm_writef(stm, "\"");
+                stm_writef(stm, b64data);
+                stm_writef(stm, "\"");
+            }
+            else
+            {
+                stm_writef(stm, "null");
+                ptr_assign(failed, TRUE);
+            }
+            heap_free(dcast(&b64data, byte_t), b64size, "JsonB64Encode");
+        }
+        else
+        {
+            stm_writef(stm, "null");
+            ptr_assign(failed, TRUE);
+        }
     }
     else
     {
@@ -794,7 +904,7 @@ static void i_write_binary(Stream *stm, const DBind *bind, const byte_t *data)
 
 /*---------------------------------------------------------------------------*/
 
-static void i_write_json_value(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data)
+static void i_write_json_value(Stream *stm, const DBind *bind, const DBind *ebind, const byte_t *data, bool_t *failed)
 {
     if (data != NULL)
     {
@@ -839,15 +949,15 @@ static void i_write_json_value(Stream *stm, const DBind *bind, const DBind *ebin
         }
 
         case ekDTYPE_STRUCT:
-            i_write_object(stm, bind, data);
+            i_write_object(stm, bind, data, failed);
             break;
 
         case ekDTYPE_BINARY:
-            i_write_binary(stm, bind, data);
+            i_write_binary(stm, bind, data, failed);
             break;
 
         case ekDTYPE_CONTAINER:
-            i_write_container(stm, bind, ebind, data);
+            i_write_container(stm, bind, ebind, data, failed);
             break;
 
         case ekDTYPE_UNKNOWN:
@@ -867,9 +977,12 @@ void json_write_imp(Stream *stm, const void *data, const JsonOpts *opts, const c
 {
     const DBind *bind = NULL;
     const DBind *ebind = NULL;
+    bool_t failed = FALSE;
     i_bind_from_typename(type, &bind, &ebind);
-    i_write_json_value(stm, bind, ebind, data);
+    i_write_json_value(stm, bind, ebind, data, &failed);
     stm_write_char(stm, 0);
+    if (failed == TRUE)
+        stm_corrupt(stm);
     unref(opts);
 }
 


### PR DESCRIPTION
## Summary

Hardens the `encode` library against memory-safety and stack-exhaustion bugs in Base64 size handling and the JSON parser.

### Base64

The previous `b64_encoded_size` computed `4 * (data_size / 3) + 5` in 32-bit arithmetic. For sufficiently large `data_size` this overflowed `uint32_t` silently and returned an undersized length. Callers such as `i_encode_from_data()` then allocated a too-small buffer and called `b64_encode`, which wrote past the end of that buffer.

This PR:

- computes encoded sizes with 64-bit arithmetic
- returns `0` from `b64_encoded_size` when the computed size is not safely representable
- intentionally rejects encoded-size results above `UINT32_MAX - 1024`, leaving a conservative 1024-byte safety margin below the `uint32_t` ceiling instead of allowing allocations and string buffers at the absolute representable limit
- adds an always-on runtime check in `b64_encode` that returns `0` and writes an empty terminator when the caller's buffer is too small
- adds `b64_decode_ex`, a bounds-checked decode API with an explicit destination size and `*written` out-parameter
- makes `b64_decode_ex` preflight the decoded output size before writing, so failure from an undersized destination is non-partial
- switches internal Base64 callers, including the JSON binary-field path, to the bounds-checked API
- avoids internal allocations when encoded-size calculation fails

If JSON binary serialization encounters a binary payload whose Base64 output would exceed the accepted size range, it now emits `null` for that field and marks the output stream corrupt instead of silently serializing the value as an empty string.

### JSON Parser

The JSON parser was mutually recursive across object, array, value, and skip/jump paths. Attacker-controlled JSON with sufficient nesting could exhaust the stack.

The parser's minus-token handling also used recursion: a long run of `-` tokens could recurse through `i_new_token` until stack exhaustion in release builds.

This PR:

- adds an internal maximum JSON nesting depth of 256
- enforces the limit on both parse and skip/jump paths
- replaces recursive minus-token handling with an iterative loop
- rejects repeated minus tokens and minus followed by a non-numeric token as invalid JSON

## Compatibility

The existing `b64_encode` and `b64_decode` APIs remain available.
`b64_decode_ex` is added as the safer API for callers that need reliable bounds enforcement.

This PR doesn't add strict Base64 syntax or padding validation; malformed input validation remains separate from buffer bounds hardening.
