### PR TITLE
Fix URL parser delimiter-order underflow

### DIFF
--- a/src/encode/url.c
+++ b/src/encode/url.c
@@ -70,23 +70,23 @@ Url *url_parse(const char_t *url)
     path_pos = str_str(start, "/");
     if (path_pos != NULL)
     {
-        const char_t *fragment_pos = str_str(start, "#");
-        const char_t *query_pos = str_str(start, "?");
-        const char_t *param_pos = str_str(start, ";");
+        const char_t *fragment_pos = str_str(path_pos, "#");
+        const char_t *query_pos = str_str(path_pos, "?");
+        const char_t *param_pos = str_str(path_pos, ";");
 
-        if (fragment_pos != NULL)
+        if (fragment_pos != NULL && fragment_pos < end)
         {
             uurl->fragment = str_cn(fragment_pos + 1, (uint32_t)(end - fragment_pos - 1));
             end = fragment_pos;
         }
 
-        if (query_pos != NULL)
+        if (query_pos != NULL && query_pos < end)
         {
             uurl->query = str_cn(query_pos + 1, (uint32_t)(end - query_pos - 1));
             end = query_pos;
         }
 
-        if (param_pos != NULL)
+        if (param_pos != NULL && param_pos < end)
         {
             uurl->params = str_cn(param_pos + 1, (uint32_t)(end - param_pos - 1));
             end = param_pos;

--- a/src/encode/url.c
+++ b/src/encode/url.c
@@ -38,6 +38,7 @@ Url *url_parse(const char_t *url)
     const char_t *end = url + str_len_c(url);
     const char_t *scheme_pos = str_str(start, ":");
     const char_t *at_sign_pos = NULL;
+    const char_t *authority_end = NULL;
     const char_t *path_pos = NULL;
     uurl->port = UINT16_MAX;
 
@@ -50,8 +51,23 @@ Url *url_parse(const char_t *url)
     if (str_str(start, "//") == start)
         start += 2;
 
+    authority_end = str_str(start, "/");
+    {
+        const char_t *query_pos = str_str(start, "?");
+        const char_t *fragment_pos = str_str(start, "#");
+
+        if (query_pos != NULL && (authority_end == NULL || query_pos < authority_end))
+            authority_end = query_pos;
+
+        if (fragment_pos != NULL && (authority_end == NULL || fragment_pos < authority_end))
+            authority_end = fragment_pos;
+
+        if (authority_end == NULL)
+            authority_end = end;
+    }
+
     at_sign_pos = str_str(start, "@");
-    if (at_sign_pos != NULL)
+    if (at_sign_pos != NULL && at_sign_pos < authority_end)
     {
         const char_t *pass_pos = str_str(start, ":");
         if (pass_pos != NULL && pass_pos < at_sign_pos)


### PR DESCRIPTION
## Summary

Fixes memory-safety and authority-boundary bugs in `url_parse`.

The parser locates the `#`, `?`, and `;` delimiters, then computes each component's length as a pointer difference between the delimiter position and a running `end` pointer, casting the result to `uint32_t` and passing it to `str_cn`.

Previously, when delimiters appeared in an order that did not match the parser's fixed processing sequence (fragment, then query, then params), `end` could be reassigned to a position before a later-processed delimiter. The subtraction `end - delim_pos - 1` then underflowed, the cast wrapped to a value near `UINT32_MAX`, and `str_cn()` was asked to copy a huge slice from a pointer near the end of caller-controlled input.

The parser now only processes `#`, `?`, and `;` when the delimiter is still inside the active `[path_pos, end)` span, and delimiter  searches start from the path instead of the authority.

This also fixes authority/path boundary handling:

- delimiters in the authority portion are no longer misparsed as path components
- `@` is only treated as userinfo when it appears inside the authority span, before the first `/`, `?`, or `#`
- `@` in the path, query, or fragment no longer rewrites the host/user split

## Example inputs

These no longer trigger wrapped component lengths or authority misparsing:

- `http://host/path#frag?query`
- `http://host/path#frag;params`
- `http://host/path?query;notparams`
- `http://host;param/path`
- `http://host/path@name`
- `http://host/path?email=a@b`
- `http://host/path#frag@tag`
